### PR TITLE
Fix for a spelling error in `create-theme.ts`

### DIFF
--- a/source/create-theme.ts
+++ b/source/create-theme.ts
@@ -76,7 +76,7 @@ const createTheme = ({variant, settings, styles}: Options): Extension => {
 			'.cm-cursor, .cm-dropCursor': {
 				borderLeftColor: settings.caret,
 			},
-			'&.cm-focused .cm-selectionBackgroundm .cm-selectionBackground, .cm-content ::selection':
+			'&.cm-focused .cm-selectionBackground .cm-selectionBackground, .cm-content ::selection':
 				{
 					backgroundColor: settings.selection,
 				},


### PR DESCRIPTION
Fixes a spelling error that would cause selection backgrounds to not be applied in some cases