### PR TITLE
Replace the exports field with main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "https://vadimdemedes.com"
 	},
 	"type": "module",
-	"exports": "./dist/index.js",
+	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"scripts": {
 		"prepare": "npm run build",


### PR DESCRIPTION
Unless you *really* want prevent people from importing themes directly (importing from the index imports everything, which is not sustainable, for example if the number of themes grows), then you should simply avoid `exports`.

It causes real-world problems, for example:

https://github.com/jspm/project/issues/320

Because of that ^ the JSPM Generator and the ES Module CDN does not let me import the subpath `/dist/themes/smoothy.js`.

This is not good because I want to be able to import one theme, and one theme only.

If someone is in a Node.js environment, they will also be limited to importing only from `dist/index.js`, and will have to import all themes.

Imagine one day `thememirror` has 1000 themes. Loading 1000 themes to only use one of the them will be waasteful as you can imagine.

So the idea here is that the `main` field still works (and always will) for things like `import {...} from 'thememirror'` but it does not restrict importing other paths, so that things like `import {...} from 'thememirror/dist/themes/smoothy.js'` also work (preferred).

For people using vanilla ES Modules in a browser with a local `importmap` poiting to `"thememirror": "node_modules/thememirror/"`, things work great, because there's no concept of `exports` in that setup. But JSPM Generator and the CDN obey Node.js `exports` rules unfortunately.